### PR TITLE
Allow SmolMIDI receive to work with busio.UART ports too

### DIFF
--- a/tests/test_winterbloom_smolmidi.py
+++ b/tests/test_winterbloom_smolmidi.py
@@ -10,7 +10,7 @@ class PortStub:
     def __init__(self, data):
         self.data = data
 
-    def readinto(self, buf, numbytes):
+    def readinto(self, buf, numbytes=1):
         bytes_read = 0
         for n in range(numbytes):
             try:
@@ -32,7 +32,7 @@ def test__read_n_bytes_empty():
     dest = []
 
     smolmidi._read_n_bytes(port, buf, dest, 0)
-    
+
     assert dest == []
 
 
@@ -42,7 +42,7 @@ def test__read_n_bytes_full():
     dest = []
 
     smolmidi._read_n_bytes(port, buf, dest, 4)
-    
+
     assert dest == [1, 2, 3, 4]
 
 def test__read_n_bytes_chunked():
@@ -51,7 +51,7 @@ def test__read_n_bytes_chunked():
     dest = []
 
     smolmidi._read_n_bytes(port, buf, dest, 4)
-    
+
     assert dest == [1, 2, 3, 4]
 
 
@@ -181,7 +181,7 @@ def test_midi_sysex_discard():
     assert msg.type == smolmidi.SYSEX
 
     msg = midi_in.receive()
-    
+
     assert msg.type == smolmidi.NOTE_ON
     assert msg.channel == 0x01
     assert msg.data[0] == 0x64

--- a/winterbloom_smolmidi.py
+++ b/winterbloom_smolmidi.py
@@ -71,10 +71,9 @@ def _is_channel_message(status_byte):
 
 def _read_n_bytes(port, buf, dest, num_bytes):
     while num_bytes:
-        if port.readinto(buf, 1):
+        if port.readinto(buf):
             dest.append(buf[0])
             num_bytes -= 1
-
 
 class Message:
     def __init__(self):
@@ -93,7 +92,7 @@ class Message:
 class MidiIn:
     def __init__(self, port, enable_running_status=False):
         self._port = port
-        self._read_buf = bytearray(3)
+        self._read_buf = bytearray(1)
         self._running_status_enabled = enable_running_status
         self._running_status = None
         self._outstanding_sysex = False
@@ -111,7 +110,7 @@ class MidiIn:
             self.receive_sysex(0)
 
         # Read the status byte for the next message.
-        result = self._port.readinto(self._read_buf, 1)
+        result = self._port.readinto(self._read_buf)
 
         # No message ready.
         if not result:
@@ -192,7 +191,7 @@ class MidiIn:
         # but sysex messages should be relatively rare in practice,
         # so I'm not sure how much benefit we'll get.
         while length < max_length:
-            self._port.readinto(buf, 1)
+            self._port.readinto(buf)
             if buf[0] == SYSEX_END:
                 break
             out.extend(buf)
@@ -204,6 +203,6 @@ class MidiIn:
             # Ignore the rest of the message by reading and throwing away
             # bytes until we get to SYSEX_END.
             while buf[0] != SYSEX_END:
-                self._port.readinto(buf, 1)
+                self._port.readinto(buf)
 
         return out, truncated


### PR DESCRIPTION
The `port.readinto()` API is slightly different for `busio.UART` (number of bytes argument not allowed).  
This change allows both `busio.UART` and `usb_midi.PortIn` objects to be used with SmolMIDI.
Tested on CircuitPython 8.2.9 on RP2040 with both USB and UART MIDI devices. Sysex was not tested, but the tests seem to pass.